### PR TITLE
Fixes cannot find module error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "normalize-selector",
 	"version": "0.0.2-a",
 	"description": "Normalize CSS Selectors",
-	"main": "./lib/normalize.js",
+	"main": "./lib/normalize-selector.js",
 	"scripts": {
 		"test": "node ./test/mocha/node-suite.js"
 	},


### PR DESCRIPTION
```
$ node test.js 

module.js:340
    throw err;
          ^
Error: Cannot find module 'normalize-selector'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/bbriggs/projects/test/test.js:1:79)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```

test.js:

```js
var normalize = require("normalize-selector");
console.log(normalize('.test'));
```

Patched to load the correct entry point.

@getify If you could merge this and release a new version on npm that'd be fantastic. :+1: